### PR TITLE
Release date

### DIFF
--- a/bin/kidash
+++ b/bin/kidash
@@ -44,6 +44,7 @@ def get_params_parser_create_dash():
     parser.add_argument("--dashboard", help="Kibana dashboard id to export")
     parser.add_argument("--export", dest="export_file", help="file with the dashboard exported")
     parser.add_argument("--import", dest="import_file", help="file with the dashboard to be imported")
+    parser.add_argument("--strict", action="store_true", help="check release date and only import newer panels")
     parser.add_argument("--kibana", dest="kibana_index", default=".kibana", help="Kibana index name (.kibana default)")
     parser.add_argument("--list", action='store_true', help="list available dashboards")
     parser.add_argument('-g', '--debug', dest='debug', action='store_true')
@@ -74,7 +75,7 @@ if __name__ == '__main__':
 
     if ARGS.import_file:
         import_dashboard(ARGS.elastic_url, ARGS.import_file, ARGS.kibana_index,
-                         ARGS.data_sources, ARGS.add_vis_studies)
+                         ARGS.data_sources, ARGS.add_vis_studies, ARGS.strict)
     elif ARGS.export_file:
         if os.path.isfile(ARGS.export_file):
             logging.info("%s exists. Remove it before running.", ARGS.export_file)

--- a/bin/kidash
+++ b/bin/kidash
@@ -92,3 +92,6 @@ if __name__ == '__main__':
         error_msg = u'%s. Content: %s' % (http_error, res.content)
         logging.error(error_msg)
 
+    except ValueError as value_error:
+        logging.error(value_error)
+

--- a/bin/kidash
+++ b/bin/kidash
@@ -28,6 +28,8 @@ import logging
 import os
 import sys
 
+from requests import HTTPError
+
 from grimoire_elk.raw.elastic import ElasticOcean
 from grimoire_elk.utils import config_logging
 from kidash.kidash import import_dashboard, export_dashboard, list_dashboards
@@ -73,13 +75,20 @@ if __name__ == '__main__':
 
     config_logging(ARGS.debug)
 
-    if ARGS.import_file:
-        import_dashboard(ARGS.elastic_url, ARGS.import_file, ARGS.kibana_index,
-                         ARGS.data_sources, ARGS.add_vis_studies, ARGS.strict)
-    elif ARGS.export_file:
-        if os.path.isfile(ARGS.export_file):
-            logging.info("%s exists. Remove it before running.", ARGS.export_file)
-            sys.exit(0)
-        export_dashboard(ARGS.elastic_url, ARGS.dashboard, ARGS.export_file, ARGS.kibana_index)
-    elif ARGS.list:
-        list_dashboards(ARGS.elastic_url, ARGS.kibana_index)
+    try:
+        if ARGS.import_file:
+            import_dashboard(ARGS.elastic_url, ARGS.import_file, ARGS.kibana_index,
+                             ARGS.data_sources, ARGS.add_vis_studies, ARGS.strict)
+        elif ARGS.export_file:
+            if os.path.isfile(ARGS.export_file):
+                logging.info("%s exists. Remove it before running.", ARGS.export_file)
+                sys.exit(0)
+            export_dashboard(ARGS.elastic_url, ARGS.dashboard, ARGS.export_file, ARGS.kibana_index)
+        elif ARGS.list:
+            list_dashboards(ARGS.elastic_url, ARGS.kibana_index)
+
+    except HTTPError as http_error:
+        res = http_error.response
+        error_msg = u'%s. Content: %s' % (http_error, res.content)
+        logging.error(error_msg)
+

--- a/kidash/kidash.py
+++ b/kidash/kidash.py
@@ -45,6 +45,7 @@ requests_ses = grimoire_con()
 
 ES_VER = None
 HEADERS_JSON = {"Content-Type": "application/json"}
+RELEASE_DATE = 'release_date'
 STUDY_PATTERN = "_study_"
 
 
@@ -728,13 +729,13 @@ def import_dashboard(elastic_url, import_file, es_index=None,
         logger.debug("Retrieving dashboard %s to check release date.", dash_id)
         current_panel = fetch_dashboard(elastic_url, dash_id, es_index)
 
-        current_release = current_panel['dashboard']['value'].get('release_date')
-        import_release = dashboard['dashboard']['value'].get('release_date')
+        current_release = current_panel['dashboard']['value'].get(RELEASE_DATE)
+        import_release = dashboard['dashboard']['value'].get(RELEASE_DATE)
 
         logger.debug("Dashboard %s current release date %s.", dash_id, current_release)
 
         if not import_release:
-            raise ValueError("'release_date' field not found in " + import_file)
+            raise ValueError("'" + RELEASE_DATE + "' field not found in " + import_file)
 
         logger.debug("New dashboard %s release date %s.", import_file, import_release)
 
@@ -870,7 +871,7 @@ def export_dashboard(elastic_url, dash_id, export_file, es_index=None):
     kibana = fetch_dashboard(elastic_url, dash_id, es_index)
 
     # Add release date to identify this particular version of the panel
-    kibana['dashboard']['value']['release_date'] = dt.utcnow().isoformat()
+    kibana['dashboard']['value'][RELEASE_DATE] = dt.utcnow().isoformat()
 
     with open(export_file, 'w') as f:
         f.write(json.dumps(kibana, indent=4, sort_keys=True))


### PR DESCRIPTION
Adds `release_date` field to panels. Also adds `strict` argument for uploading panels iif they are newer than the ones in `.kibana`.

Added a second commit to manage exceptions in order to show `content` part of responses, where ElasticSearch puts the actual reason of the error.

To use this approach with ElasticSearch + Kibana 6 we would need to modify `.kibana` mapping to include the new field because index mapping is currently set to strict, which means that no dynamic fields are allowe. The right way to do it is:
```
PUT .kibana/_mapping/doc 
{
  "properties": {
    "dashboard": {
      "properties": {
        "release_date": {
          "type": "date"
        }
      }
    }
  }
}
```
After that, the code should be working for ES + Kibana 6 too.