### PR TITLE
Add check for query key in bool filter fix

### DIFF
--- a/kidash/kidash.py
+++ b/kidash/kidash.py
@@ -157,7 +157,8 @@ def fix_dash_bool_filters(dash_json):
         meta_saved =  json.loads(dash_json["kibanaSavedObjectMeta"]["searchSourceJSON"])
         if 'filter' in meta_saved:
             for filter_ in meta_saved['filter']:
-                if 'match' in filter_['query']:
+                query = filter_.get('query')
+                if query and 'match' in query:
                     match = filter_['query']['match']
                     for field in match:
                         if match[field]['type'] == 'phrase':


### PR DESCRIPTION
This PR deals with the following error:
 
```
(grimoireelk) ➜  json git:(new-demographics) ~/venvs/grimoireelk/grimoirelab-kidash/bin/kidash -g -e https://myhost.io:443/data --import demographics.json
2018-10-16 09:47:57,319 Debug mode activated
2018-10-16 09:47:57,320 Reading panels JSON file: demographics.json
2018-10-16 09:47:57,320 Reading panel from directory: demographics.json
2018-10-16 09:47:57,321 Panel detected.
2018-10-16 09:47:57,998 Found version of ES instance at https://myhost.io:443/data: 6.
2018-10-16 09:47:58,229 Cleaning dashboard from studies vis
Traceback (most recent call last):
  File "/home/alpgarcia/venvs/grimoireelk/grimoirelab-kidash/bin/kidash", line 87, in <module>
    ARGS.data_sources, ARGS.add_vis_studies, ARGS.strict)
  File "/home/alpgarcia/venvs/grimoireelk/grimoirelab-kidash/kidash/kidash.py", line 815, in import_dashboard
    feed_dashboard(json_to_import, elastic_url, kibana_url, es_index, data_sources, add_vis_studies)
  File "/home/alpgarcia/venvs/grimoireelk/grimoirelab-kidash/kidash/kidash.py", line 963, in feed_dashboard
    dashboard['dashboard']['value'], data_sources, add_vis_studies)
  File "/home/alpgarcia/venvs/grimoireelk/grimoirelab-kidash/kidash/kidash.py", line 251, in import_item_json
    item_json = fix_dash_bool_filters(item_json)
  File "/home/alpgarcia/venvs/grimoireelk/grimoirelab-kidash/kidash/kidash.py", line 160, in fix_dash_bool_filters
    if 'match' in filter_['query']:
KeyError: 'query'
```