### PR TITLE
Update minimum Python version to 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download distribution artifact
@@ -34,10 +34,9 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
+      - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+          pipx install poetry
       - name: Install dev dependencies
         run: |
           poetry install --only dev --no-root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     name: Python ${{ matrix.python-version }}
     steps:
@@ -24,10 +24,9 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install and set up Poetry
+      - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+          pipx install poetry
       - name: Install dependencies
         run: |
           poetry install -vvv

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ are available in the [Sigils](https://github.com/chaoss/grimoirelab-sigils) repo
 
 ## Requirements
 
- * Python >= 3.9
+ * Python >= 3.10
 
 You will also need some other libraries for running the tool, you can find the
 whole list of dependencies in [pyproject.toml](pyproject.toml) file.

--- a/poetry.lock
+++ b/poetry.lock
@@ -339,5 +339,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "01d3562f7c7d71c20a3aa9a7e25ce4a58904fc04bad5e02a0dddb7a45911a410"
+python-versions = "^3.10"
+content-hash = "807c2900649a4971595ea4d1b397952f5e6b68283e615b888f05304ca3ac972d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ classifiers = [
 kidash = 'kidash.bin.kidash:main'
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
 python-dateutil = "^2.8.2"
 requests = "^2.7.0"
 urllib3 = "^2.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.1"
 coverage = "^7.2.3"
 

--- a/releases/unreleased/increased-minimum-version-for-python-to-310.yml
+++ b/releases/unreleased/increased-minimum-version-for-python-to-310.yml
@@ -1,0 +1,9 @@
+---
+title: Increased minimum version for Python to 3.10
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Python 3.9 reaches the end of life in October 2025. This means it
+  won't receive new updates or patches to fix security issues.
+  GrimoireLab supports Python 3.10 and higher from now on.


### PR DESCRIPTION
Update workflows and configuration to support Python 3.10.

Python 3.9 will no longer receive updates after October 2025. This change ensures compatibility with newer features and maintains security for the project.